### PR TITLE
SSCSCI-1868: migrate from JitPack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Template CI
+name: Dependency check
 
 on:
   pull_request:

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ dependencies {
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap'
   implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '13.6'
   implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: '13.6'
-  implementation group: 'org.json', name: 'json', version: '20250107'
+  implementation group: 'org.json', name: 'json', version: '20250517'
   implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
 
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.6'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'jacoco'
   id 'io.freefair.lombok' version '8.13.1'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '3.5.0'
+  id 'org.springframework.boot' version '3.5.3'
   id 'org.owasp.dependencycheck' version '12.1.2'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.sonarqube' version '6.1.0.5360'
@@ -234,6 +234,11 @@ dependencies {
 dependencyManagement {
   imports {
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
+  }
+
+  dependencies {
+    // CVE-2025-48976
+    dependency group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,9 @@ dependencyCheck {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url 'https://jitpack.io' }
+  maven {
+    url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
+  }
 }
 
 ext {
@@ -210,9 +212,9 @@ dependencies {
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.6'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
-  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '5.0.5'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.1'
-  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.3'
+  implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.1.0'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
+  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.4'
 
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'jacoco'
   id 'io.freefair.lombok' version '8.13.1'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '3.4.5'
+  id 'org.springframework.boot' version '3.5.0'
   id 'org.owasp.dependencycheck' version '12.1.2'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.sonarqube' version '6.1.0.5360'
@@ -219,7 +219,9 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
 
-  implementation group: 'io.rest-assured', name: 'rest-assured'
+  implementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.5', {
+    exclude group: 'org.ccil.cowan.tagsoup', module: 'tagsoup'
+  }
 
   testImplementation(platform('org.junit:junit-bom:5.12.2'))
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
@@ -230,10 +232,8 @@ dependencies {
 }
 
 dependencyManagement {
-  dependencies {
-    imports {
-      mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.1"
-    }
+  imports {
+    mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.freefair.lombok' version '8.13.1'
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.4.5'
-  id 'org.owasp.dependencycheck' version '12.1.1'
+  id 'org.owasp.dependencycheck' version '12.1.2'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.sonarqube' version '6.1.0.5360'
 }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,2 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd" />
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress until="2025-07-03">
+    <cve>CVE-2022-45688</cve>
+    <cve>CVE-2023-5072</cve>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

See [SSCSCI-1868](https://tools.hmcts.net/jira/browse/SSCSCI-1868)

### Change description ###

- Removed JitPack and added ADO Artifacts
- Dependency check plugin bump
- Spring Boot patch
- Renamed Template CI GitHub action to Dependency check because the workflow runs a dependency check only after the code is checked out.

#### Updated HMCTS repos
| Name | Change |
| --- | --- |
| [com.github.hmcts.java-logging:logging:6.1.9](https://github.com/hmcts/java-logging) | No change required |
| [com.github.hmcts:core-case-data-store-client](https://github.com/hmcts/ccd-client) | `ccd-client:5.0.5` -> `core-case-data-store-client:5.1.0` |
| [com.github.hmcts:service-auth-provider-java-client](https://github.com/hmcts/service-auth-provider-java-client) | `5.3.1` -> `5.3.2` |
| [com.github.hmcts:idam-java-client](https://github.com/hmcts/idam-java-client) | `3.0.3` -> `3.0.4` |

### Testing done

Pipelines are green, also checked in nightly-dev:
<img width="400" alt="Screenshot 2025-06-13 at 11 56 10" src="https://github.com/user-attachments/assets/7b755d77-c00f-4298-8ac5-520cc484e7e2" />

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

Added suppression for CVE-2022-45688 and CVE-2023-5072. Both look **false positive**: affecting [org.json:json](https://mvnrepository.com/artifact/org.json/json/20230618) below version 20230618 but our repo uses the latest version (20250517) and the CVE is flagged for org.apache.groovy/groovy-json@4.0.26. Most likely the CVEs are associated with the wrong repo name.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
