### PR TITLE
SSCSCI- revert dependency check upgrade

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,15 @@
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/automerge-all",
     "github>hmcts/.github//renovate/global"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "org.owasp.dependencycheck",
+        "org.owasp:dependency-check-gradle",
+        "org.owasp:dependency-check-maven"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.freefair.lombok' version '9.5.0'
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.5.14'
-  id 'org.owasp.dependencycheck' version '12.2.2'
+  id 'org.owasp.dependencycheck' version '12.2.1'
   id 'com.github.ben-manes.versions' version '0.54.0'
   id 'org.sonarqube' version '7.3.0.8198'
 }


### PR DESCRIPTION
### Change description ###

Revert dependencycheck to v 12.2.1. 

Master build is failing as hmcts db does not support this version


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
